### PR TITLE
Implement account/get using graph/node/get

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-meta-data-source: {
+graph-data-source: {
   type: "foo"
   url: "bolt://localhost:7687"
 }

--- a/src/main/scala/com/grafex/Main.scala
+++ b/src/main/scala/com/grafex/Main.scala
@@ -73,7 +73,7 @@ object Main extends IOApp {
       )
       describeMode <- Mode.instance(
         DescribeMode.definition.toLatest,
-        DescribeMode(
+        DescribeMode[IO](
           modes
             .map(_.definition)
             .map(_.asInstanceOf[Mode.Definition.Basic])

--- a/src/main/scala/com/grafex/core/DataSourceMetadata.scala
+++ b/src/main/scala/com/grafex/core/DataSourceMetadata.scala
@@ -9,8 +9,5 @@ sealed trait DataSourceMetadata {
 object DataSourceMetadata {
   final case class Id(s: String)
 
-  final case class Mongo(override val id: Id) extends DataSourceMetadata
-  final case class Mysql(override val id: Id) extends DataSourceMetadata
-  final case class FileSystem(override val id: Id) extends DataSourceMetadata
   final case class Virtual(override val id: Id) extends DataSourceMetadata
 }

--- a/src/main/scala/com/grafex/core/MetaDataSource.scala
+++ b/src/main/scala/com/grafex/core/MetaDataSource.scala
@@ -4,7 +4,6 @@ import cats.data.EitherT
 
 trait MetaDataSource[F[_]] {
   def getDataSourceById(id: String): EitherT[F, MetaDataSource.Error, DataSourceMetadata]
-  def createNode(dataSourceId: Option[String]): EitherT[F, MetaDataSource.Error, Node]
 }
 
 object MetaDataSource {

--- a/src/main/scala/com/grafex/core/ModeCallsParser.scala
+++ b/src/main/scala/com/grafex/core/ModeCallsParser.scala
@@ -1,5 +1,4 @@
-package com.grafex
-package core
+package com.grafex.core
 
 import cats.data.NonEmptyList
 import cats.syntax.either._

--- a/src/main/scala/com/grafex/core/Neo4jMetaDataSource.scala
+++ b/src/main/scala/com/grafex/core/Neo4jMetaDataSource.scala
@@ -32,29 +32,26 @@ class Neo4jMetaDataSource(config: GrafexConfiguration.Foo) extends MetaDataSourc
         .map({
           case Some((id: String, typ: String)) =>
             typ match {
-              case "mongo"   => Right(DataSourceMetadata.Mongo(DataSourceMetadata.Id(id)))
-              case "mysql"   => Right(DataSourceMetadata.Mysql(DataSourceMetadata.Id(id)))
-              case "filesys" => Right(DataSourceMetadata.FileSystem(DataSourceMetadata.Id(id)))
-              case s         => Left(MetaDataSource.Error.InvalidDataSourceType(id, s))
+              case s => Left(MetaDataSource.Error.InvalidDataSourceType(id, s))
             }
           case None => Left(MetaDataSource.Error.DataSourceNotFound(id))
         })
     })
   }
 
-  override def createNode(dataSourceId: Option[String]): EitherT[IO, MetaDataSource.Error, Node] = {
-    val session: Resource[IO, Session[IO]] = for {
-      driver <- GraphDatabase.driver[IO](
-        config.url,
-        AuthTokens.none(),
-        Config.builder().withLogging(Neo4JLogging()).build()
-      )
-      session <- driver.session
-    } yield session
+//  override def createNode[M](dataSourceId: Option[String]): EitherT[IO, MetaDataSource.Error, Node[M]] = {
+//    val session: Resource[IO, Session[IO]] = for {
+//      driver <- GraphDatabase.driver[IO](
+//        config.url,
+//        AuthTokens.none(),
+//        Config.builder().withLogging(Neo4JLogging()).build()
+//      )
+//      session <- driver.session
+//    } yield session
 
 //    EitherT(session.use { s =>
 //      c"CREATE"
 //    })
-    ???
-  }
+//    ???
+//  }
 }

--- a/src/main/scala/com/grafex/core/Node.scala
+++ b/src/main/scala/com/grafex/core/Node.scala
@@ -1,38 +1,15 @@
 package com.grafex.core
 
-sealed trait DataSourceConnection {
-  val dataSourceMetadata: DataSourceMetadata
-}
-
-object DataSourceConnection {
-
-  case class Mongo(
-    override val dataSourceMetadata: DataSourceMetadata.Mongo,
-    id: String
-  ) extends DataSourceConnection
-
-  case class Mysql(
-    override val dataSourceMetadata: DataSourceMetadata.Mysql,
-    id: String
-  ) extends DataSourceConnection
-
-  case class FileSystem(
-    override val dataSourceMetadata: DataSourceMetadata.FileSystem,
-    path: String
-  ) extends DataSourceConnection
-
-  case class Neo4J(
-    override val dataSourceMetadata: DataSourceMetadata.Virtual,
-    id: String
-  ) extends DataSourceConnection
-}
-
-case class Node(dataSourceConnection: DataSourceConnection)
+final case class Node[M](id: String, labels: List[String], source: Node.Source, metadata: M)
 
 object Node {
   object labels {
-    val AccountLabel: String = "Account"
+    val Account: String = "Account"
+    val DataSource: String = "DataSource"
+  }
+
+  sealed trait Source
+  object Source {
+    final case class Itself() extends Source
   }
 }
-
-case class Link(from: Node, to: Node)

--- a/src/main/scala/com/grafex/core/boot/ArgsParser.scala
+++ b/src/main/scala/com/grafex/core/boot/ArgsParser.scala
@@ -1,10 +1,10 @@
-package com.grafex
-package core
+package com.grafex.core
 package boot
 
 import cats.data.NonEmptyList
 import cats.data.Validated.{ Invalid, Valid }
 import cats.syntax.all._
+import com.grafex.build.BuildInfo
 import com.grafex.core.boot.Startup.{ Listener, Verbosity }
 import com.monovore.decline.{ Command, Opts }
 
@@ -48,7 +48,7 @@ object ArgsParser {
 
     val versionOpt = Opts
       .flag(long = "version", help = "Print the version number and exit")
-      .map(_ => build.BuildInfo.version)
+      .map(_ => BuildInfo.version)
       .map(Startup.Version)
 
     // Using explicitly created "help" allows to
@@ -179,7 +179,7 @@ object ArgsParser {
       )
     })
 
-    Command(build.BuildInfo.name, "Grafex", helpFlag = false)(
+    Command(BuildInfo.name, "Grafex", helpFlag = false)(
       List(
         versionOpt,
         helpOpt,

--- a/src/main/scala/com/grafex/core/boot/Config.scala
+++ b/src/main/scala/com/grafex/core/boot/Config.scala
@@ -1,5 +1,4 @@
-package com.grafex
-package core
+package com.grafex.core
 package boot
 
 import cats.data.EitherT
@@ -72,18 +71,18 @@ object Config {
   /** Contains all the application configurations. */
   case class GrafexConfiguration(
     accountId: String,
-    metaDataSource: GrafexConfiguration.MetaDataSourceConfig,
+    graphDataSource: GrafexConfiguration.GraphDataSourceConfig,
     modes: List[Json]
   )
 
   /** Contains inner structures of the [[GrafexConfiguration]] */
   object GrafexConfiguration {
 
-    sealed trait MetaDataSourceConfig
+    sealed trait GraphDataSourceConfig
 
     case class Foo(
       url: String
-    ) extends MetaDataSourceConfig
+    ) extends GraphDataSourceConfig
   }
 
   /** Represents an error of config reading. */

--- a/src/main/scala/com/grafex/core/graph/GraphDataSource.scala
+++ b/src/main/scala/com/grafex/core/graph/GraphDataSource.scala
@@ -1,0 +1,37 @@
+package com.grafex.core
+package graph
+
+import cats.data.EitherT
+
+trait GraphDataSource[F[_]] {
+
+  protected type Dec
+
+  def createNode(): EitherT[F, _, _]
+  def updateNode(): EitherT[F, _, _]
+  def deleteNode(): EitherT[F, _, _]
+  def getNode(id: String): EitherT[F, GraphDataSource.Error, Node[Map[String, String]]]
+
+  def createRelationship(): EitherT[F, _, _]
+  def updateRelationship(): EitherT[F, _, _]
+  def deleteRelationship(): EitherT[F, _, _]
+}
+
+object GraphDataSource {
+
+  /** Generic representation for [[GraphDataSource]]-related errors. */
+  sealed trait Error
+
+  /** Contains implementations of [[GraphDataSource.Error]] */
+  object Error {
+    final case class SingleError(ex: Throwable) extends Error
+    final case class IdNotFound() extends Error
+    final case class CannotDecodeId() extends Error
+    final case class LabelsNotFound() extends Error
+    final case class SourceNotFound() extends Error
+    final case class CannotDecodeLabels() extends Error
+    final case class CannotDecodeSource(t: Throwable) extends Error
+    final case class CannotDecodeMetadata() extends Error
+    final case class UnknownNodeSource(s: String) extends Error
+  }
+}

--- a/src/main/scala/com/grafex/core/graph/NodeResultDecoder.scala
+++ b/src/main/scala/com/grafex/core/graph/NodeResultDecoder.scala
@@ -1,0 +1,15 @@
+package com.grafex.core
+package graph
+
+trait NodeResultDecoder[A, B] {
+  def decode(a: A): Either[GraphDataSource.Error, Node[B]]
+}
+
+/** Factory for [[NodeResultDecoder]]. */
+object NodeResultDecoder {
+  //noinspection ConvertExpressionToSAM
+  def instance[A, B](f: A => Either[GraphDataSource.Error, Node[B]]): NodeResultDecoder[A, B] =
+    new NodeResultDecoder[A, B] {
+      override def decode(a: A): Either[GraphDataSource.Error, Node[B]] = f(a)
+    }
+}

--- a/src/main/scala/com/grafex/core/graph/neo4j/Neo4JGraphDataSource.scala
+++ b/src/main/scala/com/grafex/core/graph/neo4j/Neo4JGraphDataSource.scala
@@ -1,0 +1,140 @@
+package com.grafex.core
+package graph
+package neo4j
+
+import cats.Applicative
+import cats.data.EitherT
+import cats.instances.either._
+import cats.syntax.bifunctor._
+import neotypes.exceptions.ConversionException
+import neotypes.implicits.mappers.parameters.StringParameterMapper
+import neotypes.implicits.mappers.values.{ iterableValueMapper, StringValueMapper }
+import neotypes.implicits.syntax.cypher._
+import neotypes.mappers.{ ResultMapper, TypeHint, ValueMapper }
+import org.neo4j.driver.Value
+
+import scala.util.{ Failure, Success, Try }
+
+/** The implementation of [[GraphDataSource]] which uses Neo4J as a database backend.
+  *
+  * @param neo4jDriver neotypes' representation of Neo4J database driver
+  * @param async$F$0 neotypes' representation of Async type class for the effect F
+  * @param F Applicative type class for the effect F
+  * @tparam F the effect type
+  */
+class Neo4JGraphDataSource[F[_] : neotypes.Async](neo4jDriver: neotypes.Driver[F])(implicit F: Applicative[F])
+    extends GraphDataSource[F] {
+  import Neo4JGraphDataSource.{ genericNodeResultDecoder, genericNodeResultMapper, ValuePairList }
+
+  override protected type Dec = ValuePairList
+
+  override def createNode(): EitherT[F, _, _] = ???
+
+  override def updateNode(): EitherT[F, _, _] = ???
+
+  override def deleteNode(): EitherT[F, _, _] = ???
+
+  override def getNode(
+    id: String
+  ): EitherT[F, GraphDataSource.Error, Node[Map[String, String]]] = EitherT {
+    neo4jDriver.readSession(s => {
+      Try(
+        c""" 
+         MATCH (n {id: $id})
+         RETURN
+           n.id,
+           labels(n),
+           CASE
+             WHEN n.source IS NULL THEN "itself"
+             ELSE n.source
+           END AS source,
+           CASE n.source
+             WHEN "itself" THEN n
+             ELSE n
+           END
+         """
+          .query[Node[Map[String, String]]]
+          .single(s)
+      ) match {
+        case Failure(e) => F.pure(Left(GraphDataSource.Error.SingleError(e)))
+        case Success(v) => F.map(v)(Right(_))
+      }
+    })
+  }
+
+  override def createRelationship(): EitherT[F, _, _] = ???
+
+  override def updateRelationship(): EitherT[F, _, _] = ???
+
+  override def deleteRelationship(): EitherT[F, _, _] = ???
+}
+
+/** Contains implicits for [[Neo4JGraphDataSource]]. */
+object Neo4JGraphDataSource {
+
+  private type ValuePairList = (List[(String, Value)], Option[TypeHint])
+
+  /** neotypes' [[ValueMapper]] for "id" field. */
+  private val idMapper: ValueMapper[String] = StringValueMapper
+
+  /** neotypes' [[ValueMapper]] for "labels" field. */
+  private val labelsMapper: ValueMapper[List[String]] = iterableValueMapper[String, List]
+
+  /** neotypes' [[ResultMapper]] for node "source" field */
+  private val sourceMapper: ValueMapper[Node.Source] = ValueMapper.instance { (name: String, value: Option[Value]) =>
+    {
+      value match {
+        case Some(s) =>
+          s.asString() match {
+            case "itself" => Right(Node.Source.Itself())
+            case x        => Left(ConversionException(s"Unknown source type: $x"))
+          }
+        case None => Right(Node.Source.Itself())
+      }
+    }
+  }
+
+  private implicit def genericNodeResultDecoder: NodeResultDecoder[ValuePairList, Map[String, String]] = {
+    import neotypes.implicits.all._
+    val metadataMapper: ResultMapper[Map[String, String]] = mapResultMapper
+
+    NodeResultDecoder.instance { valuePairList: ValuePairList =>
+      {
+        val (kv, th) = valuePairList
+        for {
+          idKV <- kv.headOption
+            .toRight(GraphDataSource.Error.IdNotFound())
+          labelsKV <- kv
+            .drop(1)
+            .headOption
+            .toRight(GraphDataSource.Error.LabelsNotFound())
+          sourceKV <- kv
+            .drop(2)
+            .headOption
+            .toRight(GraphDataSource.Error.SourceNotFound())
+          id <- idMapper
+            .to(idKV._1, Some(idKV._2))
+            .leftMap(_ => GraphDataSource.Error.CannotDecodeId())
+          labels <- labelsMapper
+            .to(labelsKV._1, Some(labelsKV._2))
+            .leftMap(_ => GraphDataSource.Error.CannotDecodeLabels())
+          source <- sourceMapper
+            .to(sourceKV._1, Some(sourceKV._2))
+            .leftMap(t => GraphDataSource.Error.CannotDecodeSource(t))
+          metadata <- metadataMapper
+            .to(kv.drop(3), th)
+            .leftMap(_ => GraphDataSource.Error.CannotDecodeMetadata())
+        } yield Node(id, labels, source, metadata)
+      }
+    }
+  }
+
+  private implicit def genericNodeResultMapper[B](
+    implicit
+    nrd: NodeResultDecoder[ValuePairList, B]
+  ): ResultMapper[Node[B]] = ResultMapper.instance { (ls: List[(String, Value)], th: Option[TypeHint]) =>
+    {
+      nrd.decode((ls, th)).leftMap(e => ConversionException(e.toString))
+    }
+  }
+}

--- a/src/main/scala/com/grafex/core/internal/neo4j/package.scala
+++ b/src/main/scala/com/grafex/core/internal/neo4j/package.scala
@@ -1,4 +1,5 @@
-package com.grafex.core.internal
+package com.grafex
+package core.internal
 
 import org.neo4j.driver.{ Logger, Logging }
 import org.slf4j.LoggerFactory
@@ -30,8 +31,10 @@ package object neo4j {
     * }}}
     *
     * @note If SL4J is not is the classpath, it returns provided (or default [[Logging.console]]) failover logging.
+    *
+    * @todo make it more private
     */
-  private[core] object logging {
+  object logging {
 
     /** Instantiates a new [[Slf4jLogger]] logger or returns the failover one. */
     def apply(failover: => Logging = Logging.console(java.util.logging.Level.ALL)): Logging =

--- a/src/main/scala/com/grafex/core/package.scala
+++ b/src/main/scala/com/grafex/core/package.scala
@@ -14,9 +14,12 @@ package object core {
       exitCode
     }
 
-  trait GrafexError { self =>
+  trait GrafexError extends RuntimeException { self =>
+
+    override def getMessage: String = self.toString
+
     def errorIO: IO[ExitCode] = IO {
-      System.err.println(self)
+      System.err.println(getMessage)
       ExitCode.Error
     }
   }
@@ -45,11 +48,12 @@ package object core {
   }
 
   trait ModeError extends GrafexError
-  case class UnknownAction(actionKey: Mode.Action.Key) extends ModeError
-  case class UnsupportedInputType(inputType: InputType) extends ModeError
-  case class UnsupportedOutputType(outputType: OutputType) extends ModeError
-  case class IllegalModeState() extends ModeError // FIXME: bad error
-  case class RequestFormatError(request: Mode.SingleCallRequest, ex: Exception) extends ModeError
+  final case class UnknownAction(actionKey: Mode.Action.Key) extends ModeError
+  final case class UnsupportedInputType(inputType: InputType) extends ModeError
+  final case class UnsupportedOutputType(outputType: OutputType) extends ModeError
+  final case class IllegalModeState() extends ModeError // FIXME: bad error
+  final case class RequestFormatError(request: Mode.SingleCallRequest, ex: Exception) extends ModeError
+  final case class ResponseFormatError(response: Mode.Response, ex: Exception) extends ModeError
 
   trait RunContext[F[_]] {
     val clock: Clock[F]

--- a/src/main/scala/com/grafex/modes/datasource/DataSourceMode.scala
+++ b/src/main/scala/com/grafex/modes/datasource/DataSourceMode.scala
@@ -81,10 +81,7 @@ object DataSourceMode {
                 DSConnection(
                   id = value.id.s,
                   `type` = value match {
-                    case DataSourceMetadata.Mongo(id)      => "mongo"
-                    case DataSourceMetadata.Mysql(id)      => "mysql"
-                    case DataSourceMetadata.FileSystem(id) => "filesys"
-                    case DataSourceMetadata.Virtual(id)    => ???
+                    case DataSourceMetadata.Virtual(id) => ???
                   }
                 )
               )

--- a/src/main/scala/com/grafex/modes/datasource/DataSourceMode.scala
+++ b/src/main/scala/com/grafex/modes/datasource/DataSourceMode.scala
@@ -2,6 +2,7 @@ package com.grafex.modes.datasource
 
 import cats.data.EitherT
 import cats.effect.IO
+import com.grafex.core.Mode.ModeInitializationError
 import com.grafex.core._
 import com.grafex.core.conversion.semiauto._
 import com.grafex.core.conversion.{
@@ -14,7 +15,7 @@ import com.grafex.core.syntax.ActionRequestOps
 import com.grafex.modes.datasource.DataSourceMode.actions
 import io.circe.generic.auto._
 
-class DataSourceMode(metaDataSource: MetaDataSource[IO])(implicit runContext: RunContext[IO])
+class DataSourceMode private (metaDataSource: MetaDataSource[IO])(implicit runContext: RunContext[IO])
     extends Mode.MFunction[IO, DataSourceMode.Request, DataSourceMode.Response] {
 
   override def apply(
@@ -38,6 +39,12 @@ object DataSourceMode {
       actions.GetDataSourceMeta.definition
     )
   )
+
+  def apply(
+    metaDataSource: MetaDataSource[IO]
+  )(implicit rc: RunContext[IO]): Either[ModeInitializationError, DataSourceMode] = {
+    Right(new DataSourceMode(metaDataSource))
+  }
 
   sealed trait Request
   sealed trait Response

--- a/src/main/scala/com/grafex/modes/describe/DescribeMode.scala
+++ b/src/main/scala/com/grafex/modes/describe/DescribeMode.scala
@@ -2,14 +2,14 @@ package com.grafex.modes.describe
 
 import cats.data.EitherT
 import cats.effect.IO
-import com.grafex.core.Mode.{ MFunction, Param }
+import com.grafex.core.Mode.{ MFunction, ModeInitializationError, Param }
 import com.grafex.core._
 import com.grafex.core.conversion._
 import com.grafex.core.conversion.semiauto._
 import com.grafex.core.syntax.ActionRequestOps
 import io.circe.generic.auto._
 
-class DescribeMode(
+class DescribeMode private (
   otherDefinitions: => Seq[Mode.Definition.Callable],
   amILatest: Boolean = true
 )(implicit runContext: RunContext[IO])
@@ -41,6 +41,13 @@ object DescribeMode {
       actions.GetModeDefinition.definition
     )
   )
+
+  def apply(
+    otherDefinitions: => Seq[Mode.Definition.Callable],
+    amILatest: Boolean = true
+  )(implicit rc: RunContext[IO]): Either[ModeInitializationError, DescribeMode] = {
+    Right(new DescribeMode(otherDefinitions, amILatest))
+  }
 
   sealed trait Request
   sealed trait Response

--- a/src/main/scala/com/grafex/modes/graph/GraphMode.scala
+++ b/src/main/scala/com/grafex/modes/graph/GraphMode.scala
@@ -2,6 +2,7 @@ package com.grafex.modes.graph
 
 import cats.data.EitherT
 import cats.effect.IO
+import com.grafex.core.Mode.ModeInitializationError
 import com.grafex.core._
 import com.grafex.core.conversion.semiauto._
 import com.grafex.core.conversion.{
@@ -13,7 +14,8 @@ import com.grafex.core.conversion.{
 import com.grafex.core.syntax._
 import io.circe.generic.auto._
 
-class GraphMode(metaDataSource: MetaDataSource[IO]) extends Mode.MFunction[IO, GraphMode.Request, GraphMode.Response] {
+class GraphMode private (metaDataSource: MetaDataSource[IO])(implicit runContext: RunContext[IO])
+    extends Mode.MFunction[IO, GraphMode.Request, GraphMode.Response] {
   import GraphMode.actions
 
   override def apply(request: GraphMode.Request): EitherT[IO, ModeError, GraphMode.Response] = {
@@ -34,6 +36,12 @@ object GraphMode {
     Set(OutputType.Json),
     Set(actions.GetNode.definition)
   )
+
+  def apply(
+    metaDataSource: MetaDataSource[IO]
+  )(implicit rc: RunContext[IO]): Either[ModeInitializationError, GraphMode] = {
+    Right(new GraphMode(metaDataSource))
+  }
 
   sealed trait Request
   sealed trait Response

--- a/src/main/scala/com/grafex/modes/graph/GraphMode.scala
+++ b/src/main/scala/com/grafex/modes/graph/GraphMode.scala
@@ -1,7 +1,7 @@
 package com.grafex.modes.graph
 
 import cats.data.EitherT
-import cats.effect.IO
+import cats.effect.Sync
 import com.grafex.core.Mode.ModeInitializationError
 import com.grafex.core._
 import com.grafex.core.conversion.semiauto._
@@ -14,12 +14,12 @@ import com.grafex.core.conversion.{
 import com.grafex.core.syntax._
 import io.circe.generic.auto._
 
-class GraphMode private (metaDataSource: MetaDataSource[IO])(implicit runContext: RunContext[IO])
-    extends Mode.MFunction[IO, GraphMode.Request, GraphMode.Response] {
+class GraphMode[F[_] : Sync : RunContext] private (metaDataSource: MetaDataSource[F])
+    extends Mode.MFunction[F, GraphMode.Request, GraphMode.Response] {
   import GraphMode.actions
 
-  override def apply(request: GraphMode.Request): EitherT[IO, ModeError, GraphMode.Response] = {
-    implicit val mds: MetaDataSource[IO] = metaDataSource
+  override def apply(request: GraphMode.Request): EitherT[F, ModeError, GraphMode.Response] = {
+    implicit val mds: MetaDataSource[F] = metaDataSource
     (request match {
       case req: actions.CreateNode.Request => actions.CreateNode(req)
       case req: actions.GetNode.Request    => actions.GetNode(req)
@@ -37,9 +37,9 @@ object GraphMode {
     Set(actions.GetNode.definition)
   )
 
-  def apply(
-    metaDataSource: MetaDataSource[IO]
-  )(implicit rc: RunContext[IO]): Either[ModeInitializationError, GraphMode] = {
+  def apply[F[_] : Sync : RunContext](
+    metaDataSource: MetaDataSource[F]
+  ): Either[ModeInitializationError, GraphMode[F]] = {
     Right(new GraphMode(metaDataSource))
   }
 
@@ -56,7 +56,9 @@ object GraphMode {
         Set()
       )
 
-      def apply(request: Request)(implicit metaDataSource: MetaDataSource[IO]): EitherT[IO, ModeError, Response] = {
+      def apply[F[_] : Sync](
+        request: Request
+      )(implicit metaDataSource: MetaDataSource[F]): EitherT[F, ModeError, Response] = {
         ???
       }
 
@@ -78,7 +80,7 @@ object GraphMode {
         Set()
       )
 
-      def apply(request: Request): EitherT[IO, ModeError, Response] = {
+      def apply[F[_] : Sync](request: Request): EitherT[F, ModeError, Response] = {
         ???
       }
 

--- a/src/main/scala/com/grafex/modes/package.scala
+++ b/src/main/scala/com/grafex/modes/package.scala
@@ -1,6 +1,7 @@
 package com.grafex
 
-import com.grafex.core.{ Mode, ModeCallsParser }
+import cats.data.NonEmptyList
+import com.grafex.core.{ InputType, Mode, ModeCallsParser, OutputType }
 
 package object modes {
 
@@ -15,5 +16,17 @@ package object modes {
   def unsafeParseSingleModeCall(s: String): Mode.Call = ModeCallsParser.parse(s) match {
     case Left(error)  => sys.error(s"Unexpected error $error")
     case Right(value) => value.head
+  }
+
+  /** Returns new [[Mode.Call]] with one [[Mode.Call]].
+    * By default, uses Json as [[InputType]] and Json as [[OutputType]].
+    */
+  def createSingleModeRequest(
+    call: Mode.Call,
+    body: String,
+    inputType: InputType = InputType.Json,
+    outputType: OutputType = OutputType.Json
+  ): Mode.Request = {
+    Mode.Request(NonEmptyList(call, Nil), body, inputType, outputType)
   }
 }

--- a/src/main/scala/com/grafex/modes/package.scala
+++ b/src/main/scala/com/grafex/modes/package.scala
@@ -1,0 +1,19 @@
+package com.grafex
+
+import com.grafex.core.{ Mode, ModeCallsParser }
+
+package object modes {
+
+  /** Runs parsing of single mode call and unsafely returns the result.
+    *
+    * @throws RuntimeException in case if parsing error happened
+    *
+    * @todo Make it package private.
+    *
+    * @note Should not be used in dynamic context as it's not safe.
+    */
+  def unsafeParseSingleModeCall(s: String): Mode.Call = ModeCallsParser.parse(s) match {
+    case Left(error)  => sys.error(s"Unexpected error $error")
+    case Right(value) => value.head
+  }
+}

--- a/src/test/scala/com/grafex/core/ModeCallsParserTest.scala
+++ b/src/test/scala/com/grafex/core/ModeCallsParserTest.scala
@@ -1,5 +1,4 @@
-package com.grafex
-package core
+package com.grafex.core
 
 import cats.data.NonEmptyList
 import org.scalatest.funsuite.AnyFunSuite

--- a/src/test/scala/com/grafex/core/ModeTest.scala
+++ b/src/test/scala/com/grafex/core/ModeTest.scala
@@ -159,6 +159,7 @@ object ModeTest {
         Set(
           Action.Definition(Action.Key(Action.Name(actionName)), None, Set(Param("a")))
         )
-      )
-    )((req: Req) => EitherT.rightT(Res(s"$modeName-${req.a.toString}")))
+      ),
+      (req: Req) => EitherT.rightT[IO, ModeError](Res(s"$modeName-${req.a.toString}"))
+    )
 }

--- a/src/test/scala/com/grafex/core/ModeTest.scala
+++ b/src/test/scala/com/grafex/core/ModeTest.scala
@@ -1,19 +1,16 @@
 package com.grafex.core
 
 import cats.data.{ EitherT, NonEmptyList }
-import cats.effect.{ Clock, IO }
+import cats.effect.IO
 import cats.syntax.either._
 import com.grafex.core.Mode._
 import com.grafex.core.conversion.{ ModeRequestDecoder, ModeResponseEncoder }
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 import org.scalatest.funsuite.AnyFunSuite
 
-class ModeTest extends AnyFunSuite {
-  import ModeTest._
+class ModeTest extends AnyFunSuite with ModeTestSuite {
 
   test("Basic mode should return ByModeNameOrVersion error for wrong mode name") {
     createMode("mode")()()
@@ -123,9 +120,7 @@ class ModeTest extends AnyFunSuite {
       case Right(Mode.Response(body)) => assert(body.asJson.asObject == """{"a":"right-mode-1"}""".asJson.asObject)
     }
   }
-}
 
-object ModeTest {
   case class Req(a: Int)
   case class Res(a: String)
 
@@ -141,10 +136,7 @@ object ModeTest {
     }
   }
 
-  implicit val testRunContext: RunContext[IO] = new RunContext[IO] {
-    override val clock: Clock[IO] = Clock.create[IO]
-    override val logger: Logger[IO] = Slf4jLogger.fromName[IO]("test").unsafeRunSync() // FIXME
-  }
+  implicit val testRunContext: RunContext[IO] = createTestRunContext[IO].unsafeRunSync()
 
   def createMode(modeName: String, modeVersion: String = "1")(
     supportedInputTypes: Set[InputType] = Set(InputType.Json),

--- a/src/test/scala/com/grafex/core/ModeTestSuite.scala
+++ b/src/test/scala/com/grafex/core/ModeTestSuite.scala
@@ -1,0 +1,17 @@
+package com.grafex.core
+
+import cats.Monad
+import cats.effect.{ Clock, Sync }
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+trait ModeTestSuite {
+  def createTestRunContext[F[_] : Sync](implicit M: Monad[F]): F[RunContext[F]] = {
+    M.map(Slf4jLogger.fromName[F]("test"))(l =>
+      new RunContext[F] {
+        override val clock: Clock[F] = Clock.create[F]
+        override val logger: Logger[F] = l
+      }
+    )
+  }
+}

--- a/src/test/scala/com/grafex/core/boot/ConfigTest.scala
+++ b/src/test/scala/com/grafex/core/boot/ConfigTest.scala
@@ -1,5 +1,4 @@
-package com.grafex
-package core
+package com.grafex.core
 package boot
 
 import cats.effect.{ IO, Resource }

--- a/src/test/scala/com/grafex/modes/account/AccountModeTest.scala
+++ b/src/test/scala/com/grafex/modes/account/AccountModeTest.scala
@@ -1,0 +1,74 @@
+package com.grafex.modes
+package account
+
+import cats.data.EitherT
+import cats.effect.IO
+import cats.instances.either._
+import cats.syntax.bifunctor._
+import com.grafex.core._
+import com.grafex.core.conversion.{ ModeRequestDecoder, ModeResponseEncoder }
+import com.grafex.modes.describe.DescribeMode.UnknownModeError
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import io.circe.syntax.EncoderOps
+import org.scalatest.funsuite.AnyFunSuite
+
+class AccountModeTest extends AnyFunSuite with ModeTestSuite {
+
+  test("Account mode should create an account") {
+    val accountMode: AccountMode[IO] = AccountMode(graphMode).getOrElse(sys.error(""))
+
+    val res = accountMode.apply(AccountMode.actions.CreateAccountAction.Request("account-name")).value.unsafeRunSync()
+
+    res match {
+      case Left(error)                                                 => fail(s"Unexpected error: $error")
+      case Right(AccountMode.actions.CreateAccountAction.Response(id)) => assert(id === "id=account-name")
+      case Right(x)                                                    => fail(s"Unexpected result: $x")
+    }
+  }
+
+  sealed trait TestGraphRequest
+  sealed trait TestGraphResponse
+
+  case class TestCreateNodeRequest(label: String, metadata: Map[String, String]) extends TestGraphRequest
+  case class TestCreateNodeResponse(id: String) extends TestGraphResponse
+
+  implicit val testRunContext: RunContext[IO] = createTestRunContext[IO].unsafeRunSync()
+
+  implicit val enc: ModeResponseEncoder[TestGraphResponse] = ModeResponseEncoder.instance {
+    (res: TestGraphResponse, req: Mode.Request) =>
+      res match {
+        case r: TestCreateNodeResponse => Right(Mode.Response(r.asJson.noSpaces))
+      }
+  }
+
+  implicit val dec: ModeRequestDecoder[TestGraphRequest] = ModeRequestDecoder.instance {
+    case req if req.call.actionKey.name.toString == "node/create" =>
+      decode[TestCreateNodeRequest](req.body).leftMap(x => UnknownModeError(x.toString): ModeError)
+  }
+
+  val graphMode = Mode.instance(
+    Mode.Definition.Basic(
+      Mode.Key(Mode.Name("graph"), Mode.Version("1")),
+      None,
+      Set(InputType.Json),
+      Set(OutputType.Json),
+      Set(
+        Mode.Action.Definition(
+          Mode.Action.Key(Mode.Action.Name("create")),
+          None,
+          Set()
+        )
+      )
+    ),
+    new Mode.MFunction[IO, TestGraphRequest, TestGraphResponse] {
+      override def apply(request: TestGraphRequest): EitherT[IO, ModeError, TestGraphResponse] = {
+        request match {
+          case TestCreateNodeRequest(label, metadata) =>
+            EitherT.rightT(TestCreateNodeResponse(s"""id=${metadata("name")}"""))
+        }
+      }
+    }
+  )
+
+}


### PR DESCRIPTION
This PR introduces multiple changes:
- basic implementation for Neo4J graph data source
- implementation for `graph/node/get`
- implementation for `account/get`
- several other changes 🙂 